### PR TITLE
Ignore only Gruntfile in root.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,5 +5,5 @@
 .gitattributes
 test
 src/
-Gruntfile.js
+./Gruntfile.js
 .jshintrc


### PR DESCRIPTION
The template Gruntfile.js is missing in the npm package.
