### PR TITLE
Remove extraneous '<'

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -43,7 +43,7 @@ module.exports = function(grunt) {
         files: {
           'dist/sitemap.xml': ['src/templates/sitemap.hbs']
         }
-      }<% } %><
+      }<% } %>
       
     },
 


### PR DESCRIPTION
This is throwing an error running grunt - looks like it's in there by accident?
