### PR TITLE
NPM repo is permalinks not assemble-contrib-permalinks / Links pointing to wrong directory

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -93,7 +93,7 @@ AssembleGenerator.prototype.askFor = function askFor() {
     message : "Which plugins would you like to include?",
     choices : [
       { name: "assemble-contrib-anchors", checked: true },
-      { name: "assemble-contrib-permalinks", checked: true },
+      { name: "permalinks", checked: true },
       { name: "assemble-contrib-sitemap", checked: true },
       { name: "assemble-contrib-toc", checked: true },
       { name: "assemble-markdown-data" },

--- a/app/templates/src/templates/partials/navbar-fixed-top.hbs
+++ b/app/templates/src/templates/partials/navbar-fixed-top.hbs
@@ -6,7 +6,7 @@ component: navbar
 <div class="navbar navbar-fixed-top">
   <div class="navbar-inner">
     <div class="container">
-      <a class="navbar-brand" href="{{relative page.dest "dest/index.html"}}">ASSEMBLE</a>
+      <a class="navbar-brand" href="{{relative page.dest "dist/index.html"}}">ASSEMBLE</a>
       <button class="navbar-toggle" type="button" data-toggle="collapse" data-target="nav-collapse">
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
@@ -15,7 +15,7 @@ component: navbar
       <div class="nav-collapse collapse bs-navbar-collapse">
         <ul class="nav navbar-nav pull-right">
           <li{{#is title "Blog"}} class="active"{{/is}}>
-            <a href="{{relative page.dest "dest/blog.html"}}">Blog</a>
+            <a href="{{relative page.dest "dist/blog.html"}}">Blog</a>
           </li>
           <li> <a href="https://github.com/upstage/mixins/">GitHub Repo</a> </li>
         </ul>


### PR DESCRIPTION
While the github repo is called "assemble-contrib-permalinks", the npm package is simply named "permalinks".  As such when yeoman generates the package.json and attempts to run npm install everything asplodes.

This single change seemed to fix that problem for me.

As well there is a commit fixing a problem in the header where links are pointing to the wrong place.
