### PR TITLE
v0.4.5

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -93,7 +93,7 @@ AssembleGenerator.prototype.askFor = function askFor() {
     message : "Which plugins would you like to include?",
     choices : [
       { name: "assemble-contrib-anchors", checked: true },
-      { name: "permalinks", checked: true },
+      { name: "assemble-contrib-permalinks", checked: true },
       { name: "assemble-contrib-sitemap", checked: true },
       { name: "assemble-contrib-toc", checked: true },
       { name: "assemble-markdown-data" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-assemble",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "The scaffolding for Assemble",
   "keywords": [
     "yeoman-generator",


### PR DESCRIPTION
- Move plugin generator to its own repository
- Use `assemble-contrib-permalinks` 
