### PR TITLE
Update AUTHORS

### DIFF
--- a/app/templates/AUTHORS
+++ b/app/templates/AUTHORS
@@ -1,1 +1,1 @@
-<%= pkg.author.name %> (https://github.com/<%= authorLogin %>)
+<%= authorName %> (https://github.com/<%= authorLogin %>)


### PR DESCRIPTION
Currently when you run `yo assemble` the AUTHORS file pulls in the authorLogin variable from the Yeoman prompt, but not the authorName.

This pull request patches it, so name and login match the user's inputted values during the Yeoman generation process.
