### PR TITLE
Change assemble modules from contrib to middleware (Assemble 0.5.x). Fixes #52

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -24,10 +24,10 @@ var AssembleGenerator = yeoman.generators.Base.extend({
     this.init = this.options['init'] || this.options['i'] || false;
 
     this.defaultPlugins = {
-      "assemble-contrib-anchors": false,
-      "assemble-contrib-permalinks": true,
-      "assemble-contrib-sitemap": true,
-      "assemble-contrib-toc": false,
+      "assemble-middleware-anchors": false,
+      "assemble-middleware-permalinks": true,
+      "assemble-middleware-sitemap": true,
+      "assemble-middleware-toc": false,
     };
 
     this.config.defaults({


### PR DESCRIPTION
The `assemble:pages` grunt task would hang due to the latest version v0.5.0 of Assemble. As mentioned by @IanMercer in issue #52 simply by changing from **contrib** to **middleware** fixes this.
